### PR TITLE
Use border bottom only (applies only to iOS)

### DIFF
--- a/app/components/new-message.js
+++ b/app/components/new-message.js
@@ -24,29 +24,36 @@ class NewMessage extends Component {
 
         return (
             <View style={styles.container}>
-                <TextInput
-                  style={styles.input}
-                  placeholder="Name"
-                  value={username}
-                  onChangeText={setUsername}
+                <View style={styles.inputContainer}>
+                  <TextInput
+                    style={styles.input}
+                    placeholder="Name"
+                    value={username}
+                    onChangeText={setUsername}
                   />
-                <TextInput
-                  style={styles.input}
-                  placeholder="Message"
-                  value={newMessageText}
-                  onChangeText={setNewMessageText} />
-                  { feedback }
-                  <View style={styles.buttonContainer}>
-                    <TouchableOpacity
-                      style={styles.takePictureButton}
-                      onPress={onPickImagePressed}>
-                        <Text>Take Picture</Text>
-                    </TouchableOpacity>
-                    { sendButton }
-                  </View>
-                  <View style={styles.imageContainer}>
-                    { maybeImage }
-                  </View>
+                </View>
+
+                <View style={styles.inputContainer}>
+                  <TextInput
+                    style={styles.input}
+                    placeholder="Message"
+                    value={newMessageText}
+                    onChangeText={setNewMessageText}
+                  />
+                </View>
+                
+                { feedback }
+                <View style={styles.buttonContainer}>
+                  <TouchableOpacity
+                    style={styles.takePictureButton}
+                    onPress={onPickImagePressed}>
+                      <Text>Take Picture</Text>
+                  </TouchableOpacity>
+                  { sendButton }
+                </View>
+                <View style={styles.imageContainer}>
+                  { maybeImage }
+                </View>
             </View>
         );
     }
@@ -68,12 +75,15 @@ const styles = StyleSheet.create({
         padding: 20,
         marginTop: 100
     },
-    input: {
+    inputContainer: {
       height: 30,
       margin: 10,
       padding: 5,
-      borderWidth: 1,
+      borderBottomWidth: 1,
       borderBottomColor: 'gray'
+    },
+    input: {
+      flex: 1
     },
     buttonContainer: {
       flexDirection: 'row',


### PR DESCRIPTION
Styling av input-feltene på iOS bruker nå bare borderBottom. For at dette skal virke må det wrappes i et `<View/>` 

Borders som er spesifikke (top, bottom, left, right) fungerer ikke på `<TextInput/>` (heller ikke på `<Text/>` tror jeg). Se: https://github.com/facebook/react-native/issues/29 
